### PR TITLE
[PRIMA-8539]: Biscuit grants fix

### DIFF
--- a/commands/awskms/cfhelper.go
+++ b/commands/awskms/cfhelper.go
@@ -2,6 +2,7 @@ package awskms
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -28,7 +29,14 @@ func (s *cloudformationStack) parameterList() (output []*cloudformation.Paramete
 }
 
 func (s *cloudformationStack) createAndWait() (map[string]string, error) {
-	cfclient := cloudformation.New(session.New(&aws.Config{Region: &s.region}))
+	session, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable, // Must be set to enable
+		Config:            *aws.NewConfig().WithRegion(s.region),
+	})
+	if err != nil {
+		log.Fatal("error:", err)
+	}
+	cfclient := cloudformation.New(session)
 	createStackInput := &cloudformation.CreateStackInput{
 		StackName:    &s.stackName,
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},

--- a/commands/awskms/cfhelper.go
+++ b/commands/awskms/cfhelper.go
@@ -2,11 +2,10 @@ package awskms
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/primait/biscuit/shared"
 )
 
 type cloudformationStack struct {
@@ -29,14 +28,7 @@ func (s *cloudformationStack) parameterList() (output []*cloudformation.Paramete
 }
 
 func (s *cloudformationStack) createAndWait() (map[string]string, error) {
-	session, err := session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable, // Must be set to enable
-		Config:            *aws.NewConfig().WithRegion(s.region),
-	})
-	if err != nil {
-		log.Fatal("error:", err)
-	}
-	cfclient := cloudformation.New(session)
+	cfclient := cloudformation.New(shared.GetNewSessionWithRegion(s.region))
 	createStackInput := &cloudformation.CreateStackInput{
 		StackName:    &s.stackName,
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},

--- a/commands/awskms/kmsid.go
+++ b/commands/awskms/kmsid.go
@@ -3,8 +3,8 @@ package awskms
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/primait/biscuit/shared"
 )
 
 // KmsGetCallerIdentity prints AWS client configuration info.
@@ -12,12 +12,7 @@ type KmsGetCallerIdentity struct{}
 
 // Run prints the results of STS GetCallerIdentity.
 func (w *KmsGetCallerIdentity) Run() error {
-	session, err := session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable, // Must be set to enable
-	})
-	if err != nil {
-		return err
-	}
+	session := shared.GetNewSession()
 	credentials, err := session.Config.Credentials.Get()
 	if err != nil {
 		return err

--- a/keymanager/awskms.go
+++ b/keymanager/awskms.go
@@ -1,11 +1,9 @@
 package keymanager
 
 import (
-	"log"
-
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/primait/biscuit/shared"
 )
 
 const (
@@ -70,17 +68,7 @@ func (k *Kms) Label() string {
 func newKmsClient(arn string) (*kms.KMS, error) {
 	parsed, err := NewARN(arn)
 	if err != nil {
-		session, err := session.NewSessionWithOptions(session.Options{
-			SharedConfigState: session.SharedConfigEnable, // Must be set to enable
-		})
-		if err != nil {
-			log.Fatal("error:", err)
-		}
-		return kms.New(session), nil
+		return kms.New(shared.GetNewSession()), nil
 	}
-	session, err := session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable, // Must be set to enable
-		Config:            *aws.NewConfig().WithRegion(parsed.Region),
-	})
-	return kms.New(session), nil
+	return kms.New(shared.GetNewSessionWithRegion(parsed.Region)), nil
 }

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -1,6 +1,12 @@
 package shared
 
-import "gopkg.in/yaml.v2"
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"gopkg.in/yaml.v2"
+)
 
 // MustYaml serializes i to a YAML string, or panics if it fails to do so.
 func MustYaml(i interface{}) string {
@@ -9,4 +15,25 @@ func MustYaml(i interface{}) string {
 		panic(err)
 	}
 	return string(bytes)
+}
+
+func GetNewSession() *session.Session {
+	session, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable, // Must be set to enable
+	})
+	if err != nil {
+		log.Fatal("error:", err)
+	}
+	return session
+}
+
+func GetNewSessionWithRegion(region string) *session.Session {
+	session, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable, // Must be set to enable
+		Config:            *aws.NewConfig().WithRegion(region),
+	})
+	if err != nil {
+		log.Fatal("error:", err)
+	}
+	return session
 }


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PRIMA-8539 

**Problema**
Le sessioni sono create un po' ovunque nel codice, con l'introduzione del supporto a SSO abbiamo erroneamente "corretto" solo la decrypt dei secret poiché convinti che le session fossero centralizzate nel client kms

**Soluzione**
Ho cambiato la gestione delle session aggiungendo una funzione nel package shared (anzi due, una chiamata `GetNewSession` e una `GetNewSessionWithRegion`), di modo da centralizzare la creazione delle sessioni - lasciando invariata la logica di Doug. Ho provato una grant e non mi ha dato errori: se volete fare un double check sui comandi più comuni, top 🙏

**Impatti**
Lato dev che decryptano, nessuno. Lato ambienti, nessuno (se fanno solo decrypt la release attuale funziona, e in ogni caso avrebbe funzionato in quanto usa il ruolo). Lato noi, dovremmo finalmente riuscire a fare anche le altre azioni (init, grant) oltre la decrypt

**Come testarlo**
Con la versione attuale di biscuit, un comando come `AWS_PROFILE=tuoprofilo biscuit kms grants create --grantee-principal ruolo -f config/secrets.yml nome_segreto` fallisce

Pullando e buildando questa versione, facendo login SSO con il profilo, lo stesso comando non dovrebbe dare errori.
